### PR TITLE
feat: Add initial database schema for enrollment and campus management

### DIFF
--- a/5206db.sql
+++ b/5206db.sql
@@ -1,0 +1,435 @@
+-- 1. Campuses Table (Campus Master Data)
+-- Independent table with no foreign key dependencies
+CREATE TABLE Campuses (
+    UID2_CampusesResKey VARCHAR(50) PRIMARY KEY COMMENT 'Primary key - Campus resource identifier',
+    E525_CampusSuburb VARCHAR(100) NOT NULL COMMENT 'Campus suburb/location name',
+    E644_CampusCountryCode VARCHAR(3) NOT NULL COMMENT 'ISO country code (e.g., AUS, NZL)',
+    E559_CampusPostcode VARCHAR(10) NOT NULL COMMENT 'Campus postcode',
+    E569_CampusOperationType VARCHAR(2) NOT NULL COMMENT 'Operation type code (01=Onshore, 02=Offshore)',
+    
+    -- Indexes for query optimization
+    INDEX idx_campus_location (E559_CampusPostcode, E525_CampusSuburb),
+    INDEX idx_campus_country (E644_CampusCountryCode)
+) COMMENT='Campus master data table storing all campus locations';
+
+-- 2. HEPCoursesOnCampuses Table (Course-Campus Association)
+-- Many-to-many relationship: Courses ↔ Campuses
+CREATE TABLE HEPCoursesOnCampuses (
+    UID4_CoursesOnCampusResKey VARCHAR(50) PRIMARY KEY COMMENT 'Primary key - Course on campus identifier',
+    UID2_CampusesResKey VARCHAR(50) NOT NULL COMMENT 'Foreign key to Campuses table',
+    E525_CampusSuburb VARCHAR(100) NOT NULL COMMENT 'Campus suburb (denormalized for performance)',
+    E644_CampusCountryCode VARCHAR(3) NOT NULL COMMENT 'Campus country code',
+    E559_CampusPostcode VARCHAR(10) NOT NULL COMMENT 'Campus postcode',
+    Campuses_E609_EffectiveFromDate DATE NOT NULL COMMENT 'Campus record effective from date',
+    Campuses_E610_EffectiveToDate DATE COMMENT 'Campus record effective to date',
+    UID5_CoursesResKey VARCHAR(50) NOT NULL COMMENT 'Foreign key to HEPCourses table',
+    E307_CourseCode VARCHAR(20) NOT NULL COMMENT 'Course code (e.g., BCOM01)',
+    E597_CRICOSCode VARCHAR(20) COMMENT 'CRICOS code for international students',
+    E569_CampusOperationType VARCHAR(2) NOT NULL COMMENT 'Campus operation type',
+    E570_PrincipalOffshoreDeliveryMode VARCHAR(2) COMMENT 'Offshore delivery mode code',
+    E571_OffshoreDeliveryCode VARCHAR(2) COMMENT 'Offshore delivery type code',
+    E609_EffectiveFromDate DATE NOT NULL COMMENT 'Record effective from date',
+    E610_EffectiveToDate DATE COMMENT 'Record effective to date',
+    
+    -- Foreign key constraints
+    CONSTRAINT fk_courses_campus_campus FOREIGN KEY (UID2_CampusesResKey) 
+        REFERENCES Campuses(UID2_CampusesResKey),
+    CONSTRAINT fk_courses_campus_course FOREIGN KEY (UID5_CoursesResKey) 
+        REFERENCES HEPCourses(UID5_CoursesResKey),
+    
+    -- Performance indexes
+    INDEX idx_course_campus (UID5_CoursesResKey, UID2_CampusesResKey),
+    INDEX idx_course_code (E307_CourseCode),
+    INDEX idx_cricos (E597_CRICOSCode),
+    INDEX idx_effective_dates (E609_EffectiveFromDate, E610_EffectiveToDate)
+) COMMENT='Bridge table linking courses to campuses where they are offered';
+
+-- 3. CampusCourseFeesITSP Table (Campus Course Fees)
+-- One-to-many relationship: HEPCoursesOnCampuses → CampusCourseFeesITSP
+CREATE TABLE CampusCourseFeesITSP (
+    UID31_CampusCourseFeesResKey VARCHAR(50) PRIMARY KEY COMMENT 'Primary key - Fee record identifier',
+    UID4_CoursesOnCampusResKey VARCHAR(50) NOT NULL COMMENT 'Foreign key to courses on campus',
+    E525_CampusSuburb VARCHAR(100) NOT NULL COMMENT 'Campus suburb',
+    E644_CampusCountryCode VARCHAR(3) NOT NULL COMMENT 'Campus country code',
+    E559_CampusPostcode VARCHAR(10) NOT NULL COMMENT 'Campus postcode',
+    Campuses_E609_EffectiveFromDate DATE NOT NULL COMMENT 'Campus effective from date',
+    UID5_CoursesResKey VARCHAR(50) NOT NULL COMMENT 'Foreign key to courses',
+    E307_CourseCode VARCHAR(20) NOT NULL COMMENT 'Course code',
+    E536_CourseFeesCode VARCHAR(10) NOT NULL COMMENT 'Fee structure code',
+    E495_IndicativeStudentContributionCSP DECIMAL(10,2) COMMENT 'Commonwealth Supported Place contribution',
+    E496_IndicativeTuitionFeeDomesticFP DECIMAL(10,2) COMMENT 'Domestic fee-paying student tuition',
+    E609_EffectiveFromDate DATE NOT NULL COMMENT 'Fee effective from date',
+    
+    -- Foreign key constraints
+    CONSTRAINT fk_fees_courses_campus FOREIGN KEY (UID4_CoursesOnCampusResKey) 
+        REFERENCES HEPCoursesOnCampuses(UID4_CoursesOnCampusResKey),
+    CONSTRAINT fk_fees_course FOREIGN KEY (UID5_CoursesResKey) 
+        REFERENCES HEPCourses(UID5_CoursesResKey),
+    
+    -- Performance indexes
+    INDEX idx_course_campus_fees (UID4_CoursesOnCampusResKey),
+    INDEX idx_fees_code (E536_CourseFeesCode),
+    INDEX idx_fees_effective_date (E609_EffectiveFromDate)
+) COMMENT='Course fee information by campus and time period';
+
+-- 4. CampusesTAC Table (Tertiary Admissions Centre Offerings)
+-- One-to-many relationship: HEPCoursesOnCampuses → CampusesTAC
+CREATE TABLE CampusesTAC (
+    UID40_CoursesOnCampusTACResKey VARCHAR(50) PRIMARY KEY COMMENT 'Primary key - TAC offering identifier',
+    UID4_CoursesOnCampusResKey VARCHAR(50) NOT NULL COMMENT 'Foreign key to courses on campus',
+    E557_TACOfferCode VARCHAR(2) NOT NULL COMMENT 'TAC offer code (01=Offered through TAC, 02=Direct entry)',
+    
+    -- Foreign key constraints
+    CONSTRAINT fk_tac_courses_campus FOREIGN KEY (UID4_CoursesOnCampusResKey) 
+        REFERENCES HEPCoursesOnCampuses(UID4_CoursesOnCampusResKey),
+    
+    -- Performance indexes
+    INDEX idx_course_campus_tac (UID4_CoursesOnCampusResKey),
+    INDEX idx_tac_offer_code (E557_TACOfferCode)
+) COMMENT='Records which courses are offered through Tertiary Admissions Centres';
+
+-- 5. UnitEnrolments Table (Unit/Subject Enrolments)
+-- Multiple foreign key relationships:
+-- - HEPCourseAdmissions → UnitEnrolments (one-to-many)
+-- - HEPCoursesOnCampuses → UnitEnrolments (one-to-many, optional)
+CREATE TABLE UnitEnrolments (
+    UID16_UnitEnrolmentsResKey VARCHAR(50) NOT NULL COMMENT 'Unit enrolment identifier',
+    UID15_CourseAdmissionsResKey VARCHAR(50) NOT NULL COMMENT 'Foreign key to course admissions',
+    UID4_CoursesOnCampusResKey VARCHAR(50) COMMENT 'Foreign key to courses on campus (optional)',
+    E354_UnitOfStudyCode VARCHAR(20) NOT NULL COMMENT 'Unit/subject code (e.g., STAT1400)',
+    E489_UnitOfStudyCensusDate DATE NOT NULL COMMENT 'Census date for the unit',
+    E337_WorkExperienceInIndustryCode VARCHAR(2) COMMENT 'Work experience indicator code',
+    E551_SummerWinterSchoolCode VARCHAR(2) COMMENT 'Summer/winter school indicator',
+    E464_DisciplineCode VARCHAR(6) NOT NULL COMMENT 'Field of education discipline code',
+    E355_UnitOfStudyStatusCode VARCHAR(2) NOT NULL COMMENT 'Unit status code (10=Active, etc.)',
+    E329_ModeOfAttendanceCode VARCHAR(2) NOT NULL COMMENT 'Mode of attendance (01=Internal, 02=External)',
+    E477_DeliveryLocationPostcode VARCHAR(10) NOT NULL COMMENT 'Delivery location postcode',
+    E660_DeliveryLocationCountryCode VARCHAR(3) NOT NULL COMMENT 'Delivery location country code',
+    E490_StudentStatusCode VARCHAR(3) NOT NULL COMMENT 'Student status code (201=Active, etc.)',
+    E392_MaximumStudentContributionCode VARCHAR(2) COMMENT 'Maximum student contribution indicator',
+    E600_UnitOfStudyCommencementDate DATE NOT NULL COMMENT 'Unit start date',
+    E601_UnitOfStudyOutcomeDate DATE COMMENT 'Unit completion/outcome date',
+    UE_A111_IsDeleted BOOLEAN DEFAULT FALSE COMMENT 'Soft delete flag',
+    AsAtMonth DATE NOT NULL COMMENT 'Snapshot month for historical tracking',
+    ExtractedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT 'ETL extraction timestamp',
+    Load_Batch_ID VARCHAR(50) COMMENT 'ETL batch identifier',
+    Reporting_Year INT NOT NULL COMMENT 'Academic reporting year',
+    
+    -- Composite primary key (includes time dimension)
+    PRIMARY KEY (UID16_UnitEnrolmentsResKey, AsAtMonth),
+    
+    -- Foreign key constraints
+    CONSTRAINT fk_unit_course_admission FOREIGN KEY (UID15_CourseAdmissionsResKey) 
+        REFERENCES HEPCourseAdmissions(UID15_CourseAdmissionsResKey),
+    CONSTRAINT fk_unit_course_campus FOREIGN KEY (UID4_CoursesOnCampusResKey) 
+        REFERENCES HEPCoursesOnCampuses(UID4_CoursesOnCampusResKey),
+    
+    -- Performance indexes
+    INDEX idx_course_admission (UID15_CourseAdmissionsResKey),
+    INDEX idx_campus_course (UID4_CoursesOnCampusResKey),
+    INDEX idx_unit_code (E354_UnitOfStudyCode),
+    INDEX idx_census_date (E489_UnitOfStudyCensusDate),
+    INDEX idx_student_status (E490_StudentStatusCode),
+    INDEX idx_unit_status (E355_UnitOfStudyStatusCode),
+    INDEX idx_reporting_year (Reporting_Year),
+    INDEX idx_as_at_month (AsAtMonth),
+    INDEX idx_deleted_flag (UE_A111_IsDeleted)
+) COMMENT='Student unit/subject enrolment records with monthly snapshots';
+
+-- 6. UnitEnrolmentAOUs Table (Unit Enrolment Areas of Study)
+-- One-to-many relationship: UnitEnrolments → UnitEnrolmentAOUs
+CREATE TABLE UnitEnrolmentAOUs (
+    UID19_UnitEnrolmentAOUsResKey VARCHAR(50) NOT NULL COMMENT 'AOU record identifier',
+    UID16_UnitEnrolmentsResKey VARCHAR(50) NOT NULL COMMENT 'Foreign key to unit enrolments',
+    E333_AOUCode VARCHAR(20) NOT NULL COMMENT 'Area of Study code',
+    AOU_E339_EFTSL DECIMAL(4,3) COMMENT 'Equivalent Full-Time Student Load for AOU',
+    AOU_E384_AmountCharged DECIMAL(10,2) COMMENT 'Amount charged for AOU',
+    AOU_E381_AmountPaidUpfront DECIMAL(10,2) COMMENT 'Amount paid upfront for AOU',
+    AOU_E529_LoanFee DECIMAL(10,2) COMMENT 'Loan fee amount for AOU',
+    AOU_IsDeleted BOOLEAN DEFAULT FALSE COMMENT 'Soft delete flag',
+    AsAtMonth DATE NOT NULL COMMENT 'Snapshot month matching parent record',
+    ExtractedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT 'ETL extraction timestamp',
+    Load_Batch_ID VARCHAR(50) COMMENT 'ETL batch identifier',
+    Reporting_Year INT NOT NULL COMMENT 'Academic reporting year',
+    
+    -- Composite primary key (includes time dimension)
+    PRIMARY KEY (UID19_UnitEnrolmentAOUsResKey, AsAtMonth),
+    
+    -- Composite foreign key (matches UnitEnrolments composite primary key)
+    CONSTRAINT fk_aou_unit_enrolment FOREIGN KEY (UID16_UnitEnrolmentsResKey, AsAtMonth) 
+        REFERENCES UnitEnrolments(UID16_UnitEnrolmentsResKey, AsAtMonth),
+    
+    -- Performance indexes
+    INDEX idx_unit_enrolment (UID16_UnitEnrolmentsResKey),
+    INDEX idx_aou_code (E333_AOUCode),
+    INDEX idx_aou_deleted (AOU_IsDeleted),
+    INDEX idx_aou_month (AsAtMonth),
+    INDEX idx_aou_reporting_year (Reporting_Year)
+) COMMENT='Areas of Study breakdown for unit enrolments';
+
+-- ================================================
+-- 7. HEP_units_AOUs Table (Comprehensive Wide Table)
+-- Denormalized table combining UnitEnrolments and UnitEnrolmentAOUs
+-- Optimized for reporting and analysis
+-- ================================================
+
+CREATE TABLE `HEP_units_AOUs` (
+    UE_AOU_Key INT AUTO_INCREMENT PRIMARY KEY COMMENT 'Auto-increment primary key',
+    Student_key INT NOT NULL COMMENT 'Foreign key to HEPStudents',
+    E313_StudentIdentificationCode VARCHAR(20) NOT NULL COMMENT 'Student ID code',
+    E488_CHESSN VARCHAR(20) COMMENT 'Commonwealth Higher Ed Student Support Number',
+    UID15_CourseAdmissionsResKey VARCHAR(50) NOT NULL COMMENT 'Course admission identifier',
+    E533_CourseOfStudyCode VARCHAR(20) NOT NULL COMMENT 'Course of study code',
+    E310_CourseOfStudyType VARCHAR(2) NOT NULL COMMENT 'Course type code',
+    UID5_CoursesResKey VARCHAR(50) NOT NULL COMMENT 'Course identifier',
+    E307_CourseCode VARCHAR(20) NOT NULL COMMENT 'Course code',
+    E308_CourseName VARCHAR(200) NOT NULL COMMENT 'Course name',
+    E534_CourseOfStudyCommDate DATE NOT NULL COMMENT 'Course commencement date',
+    
+    -- Unit Enrolment Fields
+    UID16_UnitEnrolmentsResKey VARCHAR(50) NOT NULL COMMENT 'Unit enrolment identifier',
+    E354_UnitOfStudyCode VARCHAR(20) NOT NULL COMMENT 'Unit code',
+    E489_UnitOfStudyCensusDate DATE NOT NULL COMMENT 'Census date',
+    E337_WorkExperienceInIndustryCode VARCHAR(2) COMMENT 'Work experience code',
+    E551_SummerWinterSchoolCode VARCHAR(2) COMMENT 'Summer/winter school code',
+    E464_DisciplineCode VARCHAR(6) NOT NULL COMMENT 'Discipline code',
+    E355_UnitOfStudyStatusCode VARCHAR(2) NOT NULL COMMENT 'Unit status code',
+    E329_ModeOfAttendanceCode VARCHAR(2) NOT NULL COMMENT 'Attendance mode code',
+    E477_DeliveryLocationPostcode VARCHAR(10) NOT NULL COMMENT 'Delivery postcode',
+    E660_DeliveryLocationCountryCode VARCHAR(3) NOT NULL COMMENT 'Delivery country',
+    E490_StudentStatusCode VARCHAR(3) NOT NULL COMMENT 'Student status code',
+    E392_MaximumStudentContributionCode VARCHAR(2) COMMENT 'Max contribution code',
+    E600_UnitOfStudyCommencementDate DATE NOT NULL COMMENT 'Unit start date',
+    E601_UnitOfStudyOutcomeDate DATE COMMENT 'Unit outcome date',
+    E446_RemissionReasonCode VARCHAR(2) COMMENT 'Fee remission reason',
+    A130_LoanStatus VARCHAR(2) COMMENT 'HELP loan status',
+    UID21_StudentLoansResKey VARCHAR(50) COMMENT 'Student loan identifier',
+    E662_AdjustedLoanAmount DECIMAL(10,2) COMMENT 'Adjusted loan amount',
+    E663_AdjustedLoanFee DECIMAL(10,2) COMMENT 'Adjusted loan fee',
+    
+    -- Unit Enrolment Financial Fields
+    UE_E339_EFTSL DECIMAL(4,3) NOT NULL COMMENT 'Unit EFTSL value',
+    UE_E384_AmountCharged DECIMAL(10,2) NOT NULL COMMENT 'Unit amount charged',
+    UE_E381_AmountPaidUpfront DECIMAL(10,2) COMMENT 'Unit amount paid upfront',
+    UE_E558_HELPLoanAmount DECIMAL(10,2) COMMENT 'Unit HELP loan amount',
+    UE_E529_LoanFee DECIMAL(10,2) COMMENT 'Unit loan fee',
+    UE_A111_IsDeleted BOOLEAN DEFAULT FALSE COMMENT 'Unit deletion flag',
+    
+    -- AOU Fields
+    UID19_UnitEnrolmentAOUsResKey VARCHAR(50) COMMENT 'AOU identifier',
+    E333_AOUCode VARCHAR(20) COMMENT 'Area of Study code',
+    AOU_E339_EFTSL DECIMAL(4,3) COMMENT 'AOU EFTSL value',
+    AOU_E384_AmountCharged DECIMAL(10,2) COMMENT 'AOU amount charged',
+    AOU_E381_AmountPaidUpfront DECIMAL(10,2) COMMENT 'AOU amount paid upfront',
+    AOU_E529_LoanFee DECIMAL(10,2) COMMENT 'AOU loan fee',
+    AOU_IsDeleted BOOLEAN DEFAULT FALSE COMMENT 'AOU deletion flag',
+    
+    -- Time and ETL Fields
+    Year INT NOT NULL COMMENT 'Academic year',
+    Start_Date DATE NOT NULL COMMENT 'Record start date',
+    End_Date DATE COMMENT 'Record end date',
+    Is_Current BOOLEAN DEFAULT TRUE COMMENT 'Current record indicator',
+    
+    -- Foreign key constraints
+    CONSTRAINT fk_wide_student FOREIGN KEY (Student_key) 
+        REFERENCES HEPStudents(Student_Key),
+    CONSTRAINT fk_wide_admission FOREIGN KEY (UID15_CourseAdmissionsResKey) 
+        REFERENCES HEPCourseAdmissions(UID15_CourseAdmissionsResKey),
+    CONSTRAINT fk_wide_course FOREIGN KEY (UID5_CoursesResKey) 
+        REFERENCES HEPCourses(UID5_CoursesResKey),
+    CONSTRAINT fk_wide_loan FOREIGN KEY (UID21_StudentLoansResKey) 
+        REFERENCES StudentLoans(UID21_StudentLoansResKey),
+    
+    -- Performance indexes
+    INDEX idx_student (Student_key),
+    INDEX idx_student_id (E313_StudentIdentificationCode),
+    INDEX idx_chessn (E488_CHESSN),
+    INDEX idx_course_admission (UID15_CourseAdmissionsResKey),
+    INDEX idx_unit_code (E354_UnitOfStudyCode),
+    INDEX idx_census_date (E489_UnitOfStudyCensusDate),
+    INDEX idx_aou_code (E333_AOUCode),
+    INDEX idx_year (Year),
+    INDEX idx_current (Is_Current),
+    INDEX idx_unit_status_current (E355_UnitOfStudyStatusCode, Is_Current),
+    INDEX idx_student_unit_year (Student_key, E354_UnitOfStudyCode, Year)
+) COMMENT='Denormalized wide table for reporting and analytics';
+
+-- ================================================
+-- Data Integrity Check Views
+-- ================================================
+
+-- View: Check for orphaned unit enrolment records
+CREATE VIEW v_orphaned_unit_enrolments AS
+SELECT ue.*
+FROM UnitEnrolments ue
+LEFT JOIN HEPCourseAdmissions ca ON ue.UID15_CourseAdmissionsResKey = ca.UID15_CourseAdmissionsResKey
+WHERE ca.UID15_CourseAdmissionsResKey IS NULL;
+
+-- View: Currently active course-campus combinations
+CREATE VIEW v_current_courses_on_campus AS
+SELECT *
+FROM HEPCoursesOnCampuses
+WHERE (E610_EffectiveToDate IS NULL OR E610_EffectiveToDate >= CURDATE())
+  AND E609_EffectiveFromDate <= CURDATE();
+
+-- ================================================
+-- Stored Procedures for Incremental Data Updates
+-- ================================================
+
+DELIMITER $$
+
+-- Stored Procedure: Insert or update UnitEnrolments records (preserves history)
+CREATE PROCEDURE sp_upsert_unit_enrolment(
+    IN p_UID16_UnitEnrolmentsResKey VARCHAR(50),
+    IN p_UID15_CourseAdmissionsResKey VARCHAR(50),
+    IN p_AsAtMonth DATE,
+    IN p_E354_UnitOfStudyCode VARCHAR(20),
+    IN p_E489_UnitOfStudyCensusDate DATE,
+    IN p_Reporting_Year INT,
+    IN p_Load_Batch_ID VARCHAR(50)
+)
+BEGIN
+    DECLARE v_exists INT DEFAULT 0;
+    
+    -- Check if record exists
+    SELECT COUNT(*) INTO v_exists
+    FROM UnitEnrolments
+    WHERE UID16_UnitEnrolmentsResKey = p_UID16_UnitEnrolmentsResKey
+      AND AsAtMonth = p_AsAtMonth;
+    
+    IF v_exists = 0 THEN
+        -- Insert new record
+        INSERT INTO UnitEnrolments (
+            UID16_UnitEnrolmentsResKey,
+            UID15_CourseAdmissionsResKey,
+            AsAtMonth,
+            E354_UnitOfStudyCode,
+            E489_UnitOfStudyCensusDate,
+            Reporting_Year,
+            Load_Batch_ID,
+            ExtractedAt
+        ) VALUES (
+            p_UID16_UnitEnrolmentsResKey,
+            p_UID15_CourseAdmissionsResKey,
+            p_AsAtMonth,
+            p_E354_UnitOfStudyCode,
+            p_E489_UnitOfStudyCensusDate,
+            p_Reporting_Year,
+            p_Load_Batch_ID,
+            CURRENT_TIMESTAMP
+        );
+    ELSE
+        -- Update existing record's Load_Batch_ID and ExtractedAt
+        UPDATE UnitEnrolments
+        SET Load_Batch_ID = p_Load_Batch_ID,
+            ExtractedAt = CURRENT_TIMESTAMP
+        WHERE UID16_UnitEnrolmentsResKey = p_UID16_UnitEnrolmentsResKey
+          AND AsAtMonth = p_AsAtMonth;
+    END IF;
+END$$
+
+-- Stored Procedure: Generate monthly summary report
+CREATE PROCEDURE sp_generate_monthly_report(
+    IN p_reporting_month DATE
+)
+BEGIN
+    SELECT 
+        c.E525_CampusSuburb AS Campus,
+        coc.E307_CourseCode AS CourseCode,
+        COUNT(DISTINCT ue.UID16_UnitEnrolmentsResKey) AS TotalEnrolments,
+        SUM(CASE WHEN ue.E355_UnitOfStudyStatusCode = '10' THEN 1 ELSE 0 END) AS ActiveEnrolments,
+        SUM(CASE WHEN ue.UE_A111_IsDeleted = FALSE THEN 1 ELSE 0 END) AS ValidEnrolments,
+        COUNT(DISTINCT ue.E354_UnitOfStudyCode) AS UniqueUnits,
+        p_reporting_month AS ReportingMonth
+    FROM UnitEnrolments ue
+    JOIN HEPCoursesOnCampuses coc ON ue.UID4_CoursesOnCampusResKey = coc.UID4_CoursesOnCampusResKey
+    JOIN Campuses c ON coc.UID2_CampusesResKey = c.UID2_CampusesResKey
+    WHERE ue.AsAtMonth = p_reporting_month
+    GROUP BY c.E525_CampusSuburb, coc.E307_CourseCode
+    ORDER BY c.E525_CampusSuburb, coc.E307_CourseCode;
+END$$
+
+DELIMITER ;
+
+-- ================================================
+-- Triggers for Data Integrity
+-- ================================================
+
+DELIMITER $$
+
+-- Trigger: Validate parent record exists before inserting AOU
+CREATE TRIGGER trg_check_unit_enrolment_exists
+BEFORE INSERT ON UnitEnrolmentAOUs
+FOR EACH ROW
+BEGIN
+    DECLARE v_exists INT DEFAULT 0;
+    
+    SELECT COUNT(*) INTO v_exists
+    FROM UnitEnrolments
+    WHERE UID16_UnitEnrolmentsResKey = NEW.UID16_UnitEnrolmentsResKey
+      AND AsAtMonth = NEW.AsAtMonth;
+    
+    IF v_exists = 0 THEN
+        SIGNAL SQLSTATE '45000'
+        SET MESSAGE_TEXT = 'Parent UnitEnrolment record does not exist';
+    END IF;
+END$$
+
+-- Trigger: Log changes for wide table updates
+CREATE TRIGGER trg_log_unit_enrolment_changes
+AFTER INSERT ON UnitEnrolments
+FOR EACH ROW
+BEGIN
+    -- Log changes for batch processing of wide table updates
+    -- This avoids real-time updates for better performance
+    INSERT INTO update_queue (table_name, record_key, action, created_at)
+    VALUES ('UnitEnrolments', NEW.UID16_UnitEnrolmentsResKey, 'INSERT', NOW());
+END$$
+
+DELIMITER ;
+
+
+
+/*
+TABLE RELATIONSHIPS:
+
+1. ONE-TO-MANY RELATIONSHIPS:
+   - Campuses (1) → HEPCoursesOnCampuses (*)
+     One campus can host multiple courses
+   
+   - HEPCourses (1) → HEPCoursesOnCampuses (*)
+     One course can be offered at multiple campuses
+   
+   - HEPCoursesOnCampuses (1) → CampusCourseFeesITSP (*)
+     One course-campus combination can have multiple fee records over time
+   
+   - HEPCoursesOnCampuses (1) → CampusesTAC (*)
+     One course-campus combination can have multiple TAC offering methods
+   
+   - HEPCourseAdmissions (1) → UnitEnrolments (*)
+     One course admission can have multiple unit enrolments
+   
+   - HEPCoursesOnCampuses (1) → UnitEnrolments (*)
+     One course-campus combination can have multiple unit enrolments
+   
+   - UnitEnrolments (1) → UnitEnrolmentAOUs (*)
+     One unit enrolment can have multiple areas of study
+
+2. MANY-TO-MANY RELATIONSHIPS:
+   - HEPCourses (*) ↔ Campuses (*)
+     Implemented through HEPCoursesOnCampuses bridge table
+     A course can be offered at multiple campuses, a campus can offer multiple courses
+
+3. OPTIONAL RELATIONSHIPS:
+   - UnitEnrolments → HEPCoursesOnCampuses
+     UID4_CoursesOnCampusResKey can be NULL (some units may not be campus-specific)
+
+4. TEMPORAL RELATIONSHIPS:
+   - UnitEnrolments and UnitEnrolmentAOUs use composite keys with AsAtMonth
+     Supports monthly snapshots and historical data preservation
+
+5. SOFT DELETE SUPPORT:
+   - UnitEnrolments (UE_A111_IsDeleted flag)
+   - UnitEnrolmentAOUs (AOU_IsDeleted flag)
+     Maintains audit trail without physical deletion
+

--- a/sampledata_1.sql
+++ b/sampledata_1.sql
@@ -1,0 +1,321 @@
+
+-- TCSI Database Sample Data
+-- Test data for all tables with realistic Australian higher education records
+
+-- Clear existing data 
+-- DELETE FROM UnitEnrolmentAOUs;
+-- DELETE FROM UnitEnrolments;
+-- DELETE FROM CampusesTAC;
+-- DELETE FROM CampusCourseFeesITSP;
+-- DELETE FROM HEPCoursesOnCampuses;
+-- DELETE FROM StudentContactsFirstReportedAddress;
+-- DELETE FROM HEPStudentDisabilities;
+-- DELETE FROM HEPStudentCitizenships;
+-- DELETE FROM CommonwealthScholarship;
+-- DELETE FROM Campuses;
+-- DELETE FROM HEPStudents;
+
+
+-- 1. HEPStudents - Student demographic data
+
+
+INSERT INTO HEPStudents (
+    Student_Key, UID8_StudentsResKey, E313_StudentIdentificationCode, E488_CHESSN, E584_USI,
+    A170_USIVerificationStatus, A167_TFNVerificationStatus, E314_DateOfBirth,
+    E402_StudentFamilyName, E403_StudentGivenNameFirst, E404_StudentGivenNameOthers,
+    E410_ResidentialAddressLine1, E469_ResidentialAddressSuburb, E320_ResidentialAddressPostcode,
+    E470_ResidentialAddressState, E658_ResidentialAddressCountryCode,
+    E319_TermResidencePostcode, E661_TermResidenceCountryCode,
+    E315_GenderCode, E316_ATSICode, E346_CountryOfBirthCode, E347_ArrivalInAustraliaYear,
+    E348_LanguageSpokenAtHomeCode, E572_YearLeftSchool, E612_LevelLeftSchool,
+    E573_HighestEducationParent1, E574_HighestEducationParent2,
+    Start_Date, End_Date, Is_Current
+) VALUES
+-- Australian citizen students
+(100001, 'STU100001', 'S2024001', '987654321A', 'USI123456789', 'Y', 'Y', '2003-03-15',
+ 'Smith', 'Emily', 'Jane', '45 Stirling Highway', 'Crawley', '6009', 'WA', 'AUS',
+ '6009', 'AUS', '02', '04', 'AUS', NULL, '1201', 2020, '12', '08', '06',
+ '2024-01-01', NULL, TRUE),
+ 
+(100002, 'STU100002', 'S2024002', '876543210B', 'USI234567890', 'Y', 'Y', '2002-07-22',
+ 'Chen', 'Wei', 'Michael', '12 Mounts Bay Road', 'Perth', '6000', 'WA', 'AUS',
+ '6000', 'AUS', '01', '04', 'CHN', 2015, '2401', 2019, '12', '11', '11',
+ '2024-01-01', NULL, TRUE),
+
+-- International student
+(100003, 'STU100003', 'S2024003', NULL, 'USI345678901', 'Y', 'N', '2001-11-08',
+ 'Kumar', 'Priya', NULL, '78 Broadway', 'Nedlands', '6009', 'WA', 'AUS',
+ '6009', 'AUS', '02', '04', 'IND', 2023, '4202', 2019, '12', '11', '08',
+ '2024-01-01', NULL, TRUE),
+
+-- Indigenous Australian student
+(100004, 'STU100004', 'S2024004', '765432109C', 'USI456789012', 'Y', 'Y', '2004-01-25',
+ 'Williams', 'Jack', 'Thomas', '234 Cambridge Street', 'Wembley', '6014', 'WA', 'AUS',
+ '6014', 'AUS', '01', '01', 'AUS', NULL, '1201', 2021, '12', '05', '05',
+ '2024-01-01', NULL, TRUE),
+
+-- Mature age student
+(100005, 'STU100005', 'S2024005', '654321098D', 'USI567890123', 'Y', 'Y', '1985-09-30',
+ 'Anderson', 'Sarah', 'Louise', '567 Hay Street', 'Subiaco', '6008', 'WA', 'AUS',
+ '6008', 'AUS', '02', '04', 'NZL', 2010, '1201', 2003, '12', '06', '05',
+ '2024-01-01', NULL, TRUE);
+
+
+-- 2. HEPStudentCitizenships - Citizenship status
+
+
+INSERT INTO HEPStudentCitizenships (
+    UID10_StudentCitizenshipsResKey, UID8_StudentsResKey, Student_Key,
+    E313_StudentIdentificationCode, E488_CHESSN, E358_CitizenResidentCode,
+    E609_EffectiveFromDate, E610_EffectiveToDate
+) VALUES
+('CIT001', 'STU100001', 100001, 'S2024001', '987654321A', '01', '2024-01-01', NULL), -- Australian citizen
+('CIT002', 'STU100002', 100002, 'S2024002', '876543210B', '02', '2024-01-01', NULL), -- Permanent resident
+('CIT003', 'STU100003', 100003, 'S2024003', NULL, '08', '2024-01-01', NULL), -- International student
+('CIT004', 'STU100004', 100004, 'S2024004', '765432109C', '01', '2024-01-01', NULL), -- Australian citizen
+('CIT005', 'STU100005', 100005, 'S2024005', '654321098D', '01', '2024-01-01', NULL); -- Australian citizen
+
+
+-- 3. HEPStudentDisabilities - Student disability records
+
+
+INSERT INTO HEPStudentDisabilities (
+    UID11_StudentDisabilitiesResKey, UID8_StudentsResKey, Student_Key,
+    E313_StudentIdentificationCode, E488_CHESSN, E615_DisabilityCode,
+    E609_EffectiveFromDate, E610_EffectiveToDate
+) VALUES
+-- Student with learning disability
+('DIS001', 'STU100002', 100002, 'S2024002', '876543210B', '02', '2024-01-01', NULL),
+-- Student with mobility impairment
+('DIS002', 'STU100004', 100004, 'S2024004', '765432109C', '03', '2024-01-01', NULL),
+-- Student with vision impairment
+('DIS003', 'STU100005', 100005, 'S2024005', '654321098D', '04', '2024-01-01', NULL);
+
+
+-- 4. StudentContactsFirstReportedAddress - First reported addresses
+
+
+INSERT INTO StudentContactsFirstReportedAddress (
+    Student_Key, E313_StudentIdentificationCode,
+    E787_FirstResidentialAddressLine1, E789_FirstResidentialAddressSuburb,
+    E791_FirstResidentialAddressState, E659_FirstResidentialAddressCountryCode,
+    E790_FirstResidentialAddressPostcode
+) VALUES
+(100001, 'S2024001', '45 Stirling Highway', 'Crawley', 'WA', 'AUS', '6009'),
+(100002, 'S2024002', '88 Shanghai Road', 'Beijing', 'BJ', 'CHN', '100001'),
+(100003, 'S2024003', '456 MG Road', 'Mumbai', 'MH', 'IND', '400001'),
+(100004, 'S2024004', '234 Cambridge Street', 'Wembley', 'WA', 'AUS', '6014'),
+(100005, 'S2024005', '123 Queen Street', 'Auckland', 'AKL', 'NZL', '1010');
+
+
+-- 5. CommonwealthScholarship - Scholarship records
+
+
+INSERT INTO CommonwealthScholarship (
+    UID12_StudentCommonwealthScholarshipsResKey, Student_Key, E415_ReportingYear,
+    E666_ReportingPeriod, E545_CommonwealthScholarshipType, E526_CommonwealthScholarshipStatusCode,
+    E598_CommonwealthScholarshipAmount, E538_CommonwealthScholarshipTerminationReasonCode
+) VALUES
+-- Indigenous Commonwealth Scholarship
+('CWS001', 100004, 2024, '01', '01', '01', 5000.00, NULL),
+-- Commonwealth Accommodation Scholarship
+('CWS002', 100001, 2024, '01', '02', '01', 3000.00, NULL),
+-- Commonwealth Education Costs Scholarship
+('CWS003', 100002, 2024, '01', '03', '01', 2000.00, NULL);
+
+
+-- 6. Campuses - Campus locations
+
+
+INSERT INTO Campuses (
+    UID2_CampusesResKey, E525_CampusSuburb, E644_CampusCountryCode,
+    E559_CampusPostcode, E569_CampusOperationType
+) VALUES
+('CAMP001', 'Crawley', 'AUS', '6009', '01'), -- Main campus
+('CAMP002', 'Perth', 'AUS', '6000', '01'), -- City campus
+('CAMP003', 'Albany', 'AUS', '6330', '01'), -- Regional campus
+('CAMP004', 'Singapore', 'SGP', '238823', '02'), -- Offshore campus
+('CAMP005', 'Online', 'AUS', '0000', '01'); -- Online delivery
+
+
+-- 7. HEPCoursesOnCampuses - Courses offered at campuses
+
+
+-- Note: These reference HEPCourses table which should already exist
+-- Using sample course codes that would typically exist
+INSERT INTO HEPCoursesOnCampuses (
+    UID4_CoursesOnCampusResKey, UID2_CampusesResKey, E525_CampusSuburb,
+    E644_CampusCountryCode, E559_CampusPostcode, Campuses_E609_EffectiveFromDate,
+    Campuses_E610_EffectiveToDate, UID5_CoursesResKey, E307_CourseCode,
+    E597_CRICOSCode, E569_CampusOperationType, E570_PrincipalOffshoreDeliveryMode,
+    E571_OffshoreDeliveryCode, E609_EffectiveFromDate, E610_EffectiveToDate
+) VALUES
+-- Bachelor of Commerce at Crawley
+('COC001', 'CAMP001', 'Crawley', 'AUS', '6009', '2024-01-01', NULL,
+ 'CRS001', 'BCOM01', 'CRICOS001', '01', NULL, NULL, '2024-01-01', NULL),
+ 
+-- Bachelor of Science at Crawley
+('COC002', 'CAMP001', 'Crawley', 'AUS', '6009', '2024-01-01', NULL,
+ 'CRS002', 'BSCI01', 'CRICOS002', '01', NULL, NULL, '2024-01-01', NULL),
+ 
+-- Master of Business Administration at Perth City
+('COC003', 'CAMP002', 'Perth', 'AUS', '6000', '2024-01-01', NULL,
+ 'CRS003', 'MBA001', 'CRICOS003', '01', NULL, NULL, '2024-01-01', NULL),
+ 
+-- Bachelor of Commerce at Singapore (offshore)
+('COC004', 'CAMP004', 'Singapore', 'SGP', '238823', '2024-01-01', NULL,
+ 'CRS001', 'BCOM01', 'CRICOS001', '02', '01', '01', '2024-01-01', NULL),
+ 
+-- Bachelor of Arts (Online)
+('COC005', 'CAMP005', 'Online', 'AUS', '0000', '2024-01-01', NULL,
+ 'CRS004', 'BART01', NULL, '01', NULL, NULL, '2024-01-01', NULL);
+
+-- ================================================
+-- 8. CampusCourseFeesITSP - Course fees by campus
+-- ================================================
+
+INSERT INTO CampusCourseFeesITSP (
+    UID31_CampusCourseFeesResKey, UID4_CoursesOnCampusResKey, E525_CampusSuburb,
+    E644_CampusCountryCode, E559_CampusPostcode, Campuses_E609_EffectiveFromDate,
+    UID5_CoursesResKey, E307_CourseCode, E536_CourseFeesCode,
+    E495_IndicativeStudentContributionCSP, E496_IndicativeTuitionFeeDomesticFP,
+    E609_EffectiveFromDate
+) VALUES
+-- Bachelor of Commerce fees at Crawley
+('FEE001', 'COC001', 'Crawley', 'AUS', '6009', '2024-01-01',
+ 'CRS001', 'BCOM01', 'CSP1', 8750.00, 15000.00, '2024-01-01'),
+ 
+-- Bachelor of Science fees at Crawley
+('FEE002', 'COC002', 'Crawley', 'AUS', '6009', '2024-01-01',
+ 'CRS002', 'BSCI01', 'CSP2', 9500.00, 18000.00, '2024-01-01'),
+ 
+-- MBA fees at Perth City (postgrad, full fee)
+('FEE003', 'COC003', 'Perth', 'AUS', '6000', '2024-01-01',
+ 'CRS003', 'MBA001', 'FEE1', NULL, 45000.00, '2024-01-01'),
+ 
+-- Bachelor of Commerce fees at Singapore
+('FEE004', 'COC004', 'Singapore', 'SGP', '238823', '2024-01-01',
+ 'CRS001', 'BCOM01', 'INT1', NULL, 28000.00, '2024-01-01'),
+ 
+-- Bachelor of Arts fees (Online)
+('FEE005', 'COC005', 'Online', 'AUS', '0000', '2024-01-01',
+ 'CRS004', 'BART01', 'CSP1', 7500.00, 12000.00, '2024-01-01');
+
+-- ================================================
+-- 9. CampusesTAC - TAC offerings
+-- ================================================
+
+INSERT INTO CampusesTAC (
+    UID40_CoursesOnCampusTACResKey, UID4_CoursesOnCampusResKey, E557_TACOfferCode
+) VALUES
+('TAC001', 'COC001', '01'), -- BCOM through TAC
+('TAC002', 'COC002', '01'), -- BSCI through TAC
+('TAC003', 'COC003', '02'), -- MBA direct entry only
+('TAC004', 'COC005', '02'); -- BA Online direct entry
+
+-- ================================================
+-- 10. UnitEnrolments - Student unit enrolments
+-- ================================================
+
+-- Note: These reference HEPCourseAdmissions which should exist
+-- Using sample admission keys
+INSERT INTO UnitEnrolments (
+    UID16_UnitEnrolmentsResKey, UID15_CourseAdmissionsResKey, UID4_CoursesOnCampusResKey,
+    E354_UnitOfStudyCode, E489_UnitOfStudyCensusDate, E337_WorkExperienceInIndustryCode,
+    E551_SummerWinterSchoolCode, E464_DisciplineCode, E355_UnitOfStudyStatusCode,
+    E329_ModeOfAttendanceCode, E477_DeliveryLocationPostcode, E660_DeliveryLocationCountryCode,
+    E490_StudentStatusCode, E392_MaximumStudentContributionCode, 
+    E600_UnitOfStudyCommencementDate, E601_UnitOfStudyOutcomeDate,
+    UE_A111_IsDeleted, AsAtMonth, Load_Batch_ID, Reporting_Year
+) VALUES
+-- Emily Smith - Commerce units
+('UE001', 'ADM001', 'COC001', 'ACCT1001', '2024-03-31', NULL, NULL, '0801', '10', '01', 
+ '6009', 'AUS', '201', '01', '2024-02-26', NULL, FALSE, '2024-03-01', 'BATCH001', 2024),
+ 
+('UE002', 'ADM001', 'COC001', 'ECON1101', '2024-03-31', NULL, NULL, '1401', '10', '01',
+ '6009', 'AUS', '201', '01', '2024-02-26', NULL, FALSE, '2024-03-01', 'BATCH001', 2024),
+
+-- Wei Chen - Science units  
+('UE003', 'ADM002', 'COC002', 'MATH1001', '2024-03-31', NULL, NULL, '0101', '10', '01',
+ '6009', 'AUS', '201', '01', '2024-02-26', NULL, FALSE, '2024-03-01', 'BATCH001', 2024),
+ 
+('UE004', 'ADM002', 'COC002', 'CHEM1003', '2024-03-31', NULL, NULL, '0301', '10', '01',
+ '6009', 'AUS', '201', '01', '2024-02-26', NULL, FALSE, '2024-03-01', 'BATCH001', 2024),
+
+-- Priya Kumar - MBA units (intensive mode)
+('UE005', 'ADM003', 'COC003', 'MBA501', '2024-03-31', NULL, NULL, '0803', '10', '02',
+ '6000', 'AUS', '201', NULL, '2024-03-01', NULL, FALSE, '2024-03-01', 'BATCH001', 2024),
+
+-- Jack Williams - Commerce with work placement
+('UE006', 'ADM004', 'COC001', 'MGMT2001', '2024-03-31', '01', NULL, '0803', '10', '01',
+ '6009', 'AUS', '201', '01', '2024-02-26', NULL, FALSE, '2024-03-01', 'BATCH001', 2024),
+
+-- Sarah Anderson - Online Arts
+('UE007', 'ADM005', 'COC005', 'ENGL1001', '2024-03-31', NULL, NULL, '2001', '10', '04',
+ '0000', 'AUS', '201', '01', '2024-02-26', NULL, FALSE, '2024-03-01', 'BATCH001', 2024),
+
+-- Summer school unit
+('UE008', 'ADM001', 'COC001', 'STAT1400', '2024-01-15', NULL, '01', '0101', '10', '01',
+ '6009', 'AUS', '201', '01', '2024-01-02', '2024-02-15', FALSE, '2024-01-01', 'BATCH001', 2024);
+
+-- ================================================
+-- 11. UnitEnrolmentAOUs - Areas of Study
+-- ================================================
+
+INSERT INTO UnitEnrolmentAOUs (
+    UID19_UnitEnrolmentAOUsResKey, UID16_UnitEnrolmentsResKey, E333_AOUCode,
+    AOU_E339_EFTSL, AOU_E384_AmountCharged, AOU_E381_AmountPaidUpfront,
+    AOU_E529_LoanFee, AOU_IsDeleted, AsAtMonth, Load_Batch_ID, Reporting_Year
+) VALUES
+-- Accounting AOU for ACCT1001
+('AOU001', 'UE001', 'ACCT-MAJ', 0.125, 2187.50, 500.00, 0.00, FALSE, '2024-03-01', 'BATCH001', 2024),
+
+-- Economics AOU for ECON1101  
+('AOU002', 'UE002', 'ECON-MAJ', 0.125, 2187.50, 0.00, 109.38, FALSE, '2024-03-01', 'BATCH001', 2024),
+
+-- Mathematics AOU for MATH1001
+('AOU003', 'UE003', 'MATH-MAJ', 0.125, 2375.00, 1000.00, 0.00, FALSE, '2024-03-01', 'BATCH001', 2024),
+
+-- Chemistry AOU for CHEM1003
+('AOU004', 'UE004', 'CHEM-MAJ', 0.125, 2375.00, 0.00, 118.75, FALSE, '2024-03-01', 'BATCH001', 2024),
+
+-- MBA Core AOU
+('AOU005', 'UE005', 'MBA-CORE', 0.167, 7500.00, 7500.00, 0.00, FALSE, '2024-03-01', 'BATCH001', 2024),
+
+-- Management AOU with split between major and minor
+('AOU006', 'UE006', 'MGMT-MAJ', 0.083, 1458.33, 0.00, 72.92, FALSE, '2024-03-01', 'BATCH001', 2024),
+('AOU007', 'UE006', 'MGMT-MIN', 0.042, 729.17, 0.00, 36.46, FALSE, '2024-03-01', 'BATCH001', 2024),
+
+-- English Literature AOU
+('AOU008', 'UE007', 'ENGL-MAJ', 0.125, 1875.00, 500.00, 0.00, FALSE, '2024-03-01', 'BATCH001', 2024),
+
+-- Statistics AOU (Summer)
+('AOU009', 'UE008', 'STAT-MIN', 0.125, 2187.50, 2187.50, 0.00, FALSE, '2024-01-01', 'BATCH001', 2024);
+
+
+-- Summary Statistics
+
+
+SELECT 'Data Load Summary' as Report;
+
+SELECT 'HEPStudents' as Table_Name, COUNT(*) as Record_Count FROM HEPStudents
+UNION ALL
+SELECT 'HEPStudentCitizenships', COUNT(*) FROM HEPStudentCitizenships
+UNION ALL
+SELECT 'HEPStudentDisabilities', COUNT(*) FROM HEPStudentDisabilities
+UNION ALL
+SELECT 'StudentContactsFirstReportedAddress', COUNT(*) FROM StudentContactsFirstReportedAddress
+UNION ALL
+SELECT 'CommonwealthScholarship', COUNT(*) FROM CommonwealthScholarship
+UNION ALL
+SELECT 'Campuses', COUNT(*) FROM Campuses
+UNION ALL
+SELECT 'HEPCoursesOnCampuses', COUNT(*) FROM HEPCoursesOnCampuses
+UNION ALL
+SELECT 'CampusCourseFeesITSP', COUNT(*) FROM CampusCourseFeesITSP
+UNION ALL
+SELECT 'CampusesTAC', COUNT(*) FROM CampusesTAC
+UNION ALL
+SELECT 'UnitEnrolments', COUNT(*) FROM UnitEnrolments
+UNION ALL
+SELECT 'UnitEnrolmentAOUs', COUNT(*) FROM UnitEnrolmentAOUs;


### PR DESCRIPTION
This commit introduces the initial database schema to support the enrollment, campus, and course management features.

The following tables have been created based on the provided data files:

- UnitEnrolment: Tracks individual unit enrollments.
- UnitEnrolmentAOUs: Manages AOU information related to enrollments.
- CampusesTAC: Stores campus-specific TAC details.
- HEPCoursesOnCampuses: Links HEPCourses to specific campuses.
- CampusCourseFeesITSP: Records course fees for different campuses.
- Campuses: Stores foundational information for all campuses.