### PR TITLE
Add triggers to update 'is_current' field

### DIFF
--- a/db/schema/01_students.sql
+++ b/db/schema/01_students.sql
@@ -38,6 +38,24 @@ CREATE TABLE hep_students (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     is_current BOOLEAN DEFAULT TRUE
 );
+-- Triggers to update "is_current" to false after new insert is added
+-- Trigger function
+CREATE FUNCTION student_is_current()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE hep_students
+    SET is_current = FALSE
+    WHERE uid8_students_res_key = NEW.uid8_students_res_key 
+        AND is_current = TRUE;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- Trigger
+CREATE TRIGGER trg_student_is_current
+BEFORE INSERT ON hep_students
+FOR EACH ROW
+EXECUTE FUNCTION student_is_current();
+
 
 -- Student Citizenships
 CREATE TABLE hep_student_citizenships (
@@ -53,6 +71,7 @@ CREATE TABLE hep_student_citizenships (
     is_current BOOLEAN DEFAULT TRUE,
     CONSTRAINT uq_student_citizenship UNIQUE (student_id, e358_citizen_resident_code, e609_effective_from_date)
 );
+
 
 -- Student Disabilities
 CREATE TABLE hep_student_disabilities (

--- a/db/schema/03_course_admissions.sql
+++ b/db/schema/03_course_admissions.sql
@@ -25,6 +25,24 @@ CREATE TABLE hep_course_admissions (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     is_current BOOLEAN DEFAULT TRUE
 );
+-- Add trigger to keep is_current up to date
+-- Trigger function
+CREATE OR REPLACE FUNCTION course_admission_is_current()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE hep_course_admissions
+    SET is_current = FALSE
+    WHERE uid15_course_admissions_res_key = NEW.uid15_course_admissions_res_key
+        AND is_current = TRUE;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- Trigger
+CREATE TRIGGER trg_update_is_current
+BEFORE INSERT ON hep_course_admissions
+FOR EACH ROW
+EXECUTE FUNCTION course_admission_is_current();
+
 
 -- Basis for Admission
 CREATE TABLE hep_basis_for_admission (

--- a/db/schema/04_loans.sql
+++ b/db/schema/04_loans.sql
@@ -33,6 +33,23 @@ CREATE TABLE oshelp (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     is_current BOOLEAN DEFAULT TRUE
 );
+-- Add trigger to keep is_current up to date
+-- Trigger function
+CREATE OR REPLACE FUNCTION oshelp_is_current()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE oshelp
+    SET is_current = FALSE
+    WHERE uid21_student_loans_res_key = NEW.uid21_student_loans_res_key
+        AND is_current = TRUE;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- Trigger
+CREATE TRIGGER trg_oshelp_is_current
+BEFORE INSERT ON oshelp
+FOR EACH ROW
+EXECUTE FUNCTION oshelp_is_current();
 
 -- SA-HELP Loans
 CREATE TABLE sahelp (

--- a/db/schema/07_unit_enrolments.sql
+++ b/db/schema/07_unit_enrolments.sql
@@ -32,6 +32,23 @@ CREATE TABLE unit_enrolments (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     is_current BOOLEAN DEFAULT TRUE
 );
+-- Add trigger to keep is_current up to DATE
+-- Trigger function
+CREATE FUNCTION unit_enrolment_is_current()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE unit_enrolments
+    SET is_current = FALSE
+    WHERE uid16_unit_enrolments_res_key = NEW.uid16_unit_enrolments_res_key
+        AND is_current = TRUE;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- Trigger
+CREATE TRIGGER trg_unit_enrolment_is_current
+BEFORE INSERT ON unit_enrolments
+FOR EACH ROW
+EXECUTE FUNCTION unit_enrolment_is_current();
 
 -- Academic Organisations (AOUs) for Unit Enrolments
 CREATE TABLE unit_enrolments_aous (


### PR DESCRIPTION
This pull request add triggers to update "is_current" field.

Next thing to do:

There are seven main relationships in the current database schema (i.e relationship regarding students, courses, course_admissions, loans, awards, campuses, unit enrolments). Each relationship contains a main table, and there are tow identifiers for the entity if it contains "is_current" field, which are its id defined by us and its uid provided by TCSI. And the id field serves as foreign key in the child tables (of the main table), its nature determines its value will not be repeated, so we have to create another kind of trigger to update its corresponding fields.